### PR TITLE
Fix incorrect ESM pointers in manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "source": "src/index.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
   "module": "dist/index.mjs",
   "source": "src/index.ts",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Hi, thanks for taking over the maintenance of this project 🙏🏾 

This PR fixes a small problem I had with Vitest where it couldn't find the modules under Node environment.

Since you're specifying `"type": "module"` in your `package.json` that causes Node.js (and thus Vitest) to treat `.js` files as ES modules, where require is not allowed.

## Repro

Clone [this repo](https://github.com/giammyisjammy/rhf-mantine-repro) and run `yarn vitest`:

Expected output:
```zsh
❯ yarn vitest

 RUN  v3.2.3 /home/giammyisjammy/Projects/vite-template

 ✓ src/components/Welcome/Welcome.test.tsx (1 test) 28ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/components/Form/Form.test.tsx [ src/components/Form/Form.test.tsx ]
ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/home/gbado/Projects/test-nuovi-bindings-mantine/node_modules/@trendcapital/react-hook-form-mantine/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
 ❯ node_modules/@trendcapital/react-hook-form-mantine/dist/index.js:3:19
      1| 'use strict';
      2| 
      3| var AngleSlider = require('./AngleSlider.js');
       |                   ^
      4| var Autocomplete = require('./Autocomplete.js');
      5| var Checkbox = require('./Checkbox.js');
 ❯ src/components/Form/Form.tsx:2:1

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed | 1 passed (2)
      Tests  1 passed (1)
   Start at  13:17:13
   Duration  795ms (transform 87ms, setup 62ms, collect 367ms, tests 28ms, environment 369ms, prepare 108ms)
```
