### PR TITLE
Support React 18.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
   "peerDependencies": {
     "@mantine/core": ">=8.0.0",
     "@mantine/dates": ">=8.0.0",
-    "react": ">=19.0.0",
-    "react-dom": ">=19.0.0",
+    "react": "^18.x || ^19.x",
+    "react-dom": "^18.x || ^19.x",
     "react-hook-form": ">=7.43.0"
   }
 }


### PR DESCRIPTION
Referring to Trend-Capital/react-hook-form-mantine#2 I opened a PR.

I'm fairly convinced that, as of now, there's no need to do anything besides the `peerDependencies` version update. 

Feel free to discuss and give feedback 🙏🏾 

Edit: for context, I followed the version number in the `peerDependencies` of [`@mantine/core/package.json`](https://github.com/mantinedev/mantine/blob/6979187e185e6b3f6203718353a00e23d1cdf27f/packages/%40mantine/core/package.json#L45).